### PR TITLE
Fix undefined variable check

### DIFF
--- a/jquery.imagesloaded.js
+++ b/jquery.imagesloaded.js
@@ -40,7 +40,7 @@
 
     $images.bind( 'load error',  imgLoaded ).each( function() {
       // cached images don't fire load sometimes, so we reset src.
-      if (this.complete || this.complete === undefined){
+      if (this.complete || typeof this.complete === "undefined"){
         var src = this.src;
         // webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f
         // data uri bypasses webkit log warning (thx doug jones)


### PR DESCRIPTION
The following check will fail in IE if `this.complete` has not been declared because the identity operator fails on undeclared variables:

```
this.complete || this.complete === undefined
```

This change fixes this problem by using `typeof this.complete === "undefined"`.

This may fix #8.
