### PR TITLE
Fixed loaded images check

### DIFF
--- a/jquery.imagesloaded.js
+++ b/jquery.imagesloaded.js
@@ -33,7 +33,7 @@
         loaded.push(this);
         if ( --len <= 0 ){
           setTimeout( triggerCallback );
-          $images.unbind( 'load error', imgLoaded );
+          $images.unbind( '.imagesLoaded', imgLoaded );
         }
       }
     }
@@ -42,7 +42,7 @@
       triggerCallback();
     }
 
-    $images.bind( 'load error',  imgLoaded ).each( function() {
+    $images.bind( 'load.imagesLoaded error.imagesLoaded',  imgLoaded ).each( function() {
       // cached images don't fire load sometimes, so we reset src.
       var src = this.src;
       // webkit hack from http://groups.google.com/group/jquery-dev/browse_thread/thread/eee6ab7b2da50e1f


### PR DESCRIPTION
Following the comment in **justinhillsjohnson** pull request...

As I've been unable to find a reliable cross-browser method to determine that image has finished loading (working for broken and non-broken images), I came up with this solution.

It basically resets all `this.src` attributes available without any condition requirement, while caching the images that already received a proper load/error event, and checking the new load/error event source against this array.

It works flawlessly everywhere (at least I don't see any way how could it fail, tested in IE6, IE7, IE8, IE9, FF8, Opera 11.52, Chrome 15, and Safari 5.1.1), but as I've mentioned in previous pull request, changing the `src` attribute while the image is still loading might have some negative effect?? ... haven't noticed any difference myself, but please share your thoughts.
