### PR TITLE
Use named functions for image handlers to allow multiple bindings and unbindings.

### DIFF
--- a/jquery.imagesloaded.js
+++ b/jquery.imagesloaded.js
@@ -82,7 +82,7 @@ $.fn.imagesLoaded = function( callback ) {
 		// call doneLoading and clean listeners if all images are loaded
 		if ( $images.length === loaded.length ) {
 			setTimeout( doneLoading );
-			$images.unbind( 'load.imagesLoaded error.imagesLoaded', imgLoadedHandler );
+			$images.unbind( '.imagesLoaded', imgLoadedHandler );
 		}
 	}
 


### PR DESCRIPTION
Currently imagesLoaded relies on a namespace to unbind the event handlers for 'load' and 'error' that it attaches. However, multiple invocations of imagesLoaded that affect the same image will still conflict, where one invocation could remove the event handlers attached by another.

This pull request fixes this behavior by using a named function variable for binding and unbinding, thus assuring that each invocation removes only the event handlers created by it.
