### PR TITLE
IE 8 Invalid Pointer

### DIFF
--- a/jquery.imagesloaded.js
+++ b/jquery.imagesloaded.js
@@ -57,7 +57,7 @@ $.fn.imagesLoaded = function( callback ) {
 
 	function imgLoaded( img, isBroken ) {
 		// don't proceed if BLANK image, or image is already loaded
-		if ( typeof img.src === "string" && ( img.src === BLANK || $.inArray( img, loaded ) !== -1 ) ) {
+		if ( typeof img.src !== "string" || img.src === BLANK || $.inArray( img, loaded ) !== -1 ) {
 			return;
 		}
 


### PR DESCRIPTION
Using IE 8, the entire script would fail due to an "invalid pointer" that would occur in two places, that was apparently being caused by an unassigned object attribute, namely `img.src`. I've stopped these from occurring by doing a `typeof` check on the attribute before any operations.

![invalid-pointer](https://f.cloud.github.com/assets/543788/60773/edfb6794-5c20-11e2-8611-6ba381eb2058.PNG)
