### PR TITLE
Use requirejs to Create Packaged Version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,6 +3,7 @@
 
 module.exports = function( grunt ) {
 
+  var _ = grunt.util._;
   var bowerJSON = grunt.file.readJSON('bower.json');
 
   // get banner comment from draggabilly.js
@@ -15,13 +16,16 @@ module.exports = function( grunt ) {
 
   grunt.initConfig({
 
-    concat: {
+    requirejs: {
       pkgd: {
-        // src will be set in package-sources task
-        src: [ bowerJSON.main ],
-        dest: 'imagesloaded.pkgd.js',
         options: {
-          banner: banner
+          name: bowerJSON.name,
+          out: 'imagesloaded.pkgd.js',
+          baseUrl: './',
+          optimize: 'none',
+          wrap: {
+            start: banner
+          }
         }
       }
     },
@@ -40,17 +44,17 @@ module.exports = function( grunt ) {
     watch: {
       content: {
         files: [ 'assets/*', 'README.md' ],
-        tasks: [ 'concat', 'page', 'copy' ]
+        tasks: [ 'bower-list-sources', 'requirejs', 'page', 'copy' ]
       },
       js: {
         files: [ 'imagesloaded.js' ],
-        tasks: [ 'concat', 'uglify' ]
+        tasks: [ 'bower-list-sources', 'requirejs', 'uglify' ]
       }
     }
 
   });
 
-  grunt.loadNpmTasks('grunt-contrib-concat');
+  grunt.loadNpmTasks('grunt-contrib-requirejs');
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
@@ -60,7 +64,7 @@ module.exports = function( grunt ) {
 
   grunt.registerTask( 'default', [
     'bower-list-sources',
-    'concat',
+    'requirejs',
     'uglify',
     'page'
   ]);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-watch": "~0.3.1",
     "highlight.js": "~7.3.0",
-    "marked": "~0.2.8"
+    "marked": "~0.2.8",
+    "grunt-contrib-requirejs": "~0.4.1"
   },
   "repository": {
     "type": "git",

--- a/tasks/bower-list-sources.js
+++ b/tasks/bower-list-sources.js
@@ -9,10 +9,24 @@ module.exports = function( grunt ) {
   'use strict';
 
   grunt.registerTask( 'bower-list-sources', function() {
+    var _ = grunt.util._;
     var done = this.async();
+    var jsRe = /\.js$/i
+
+    var extractPath = function(files) {
+      var path;
+      if (_.isString(files)) {
+        path = files;
+      } else {
+        path = _.filter(files, function(el) { return jsRe.test(el); })[0];
+      }
+      if (path) {
+        return path.replace(jsRe, '');
+      }
+    }
 
     // get map JSON from bower list --map
-    var childProc = spawn('bower', 'list --sources'.split(' ') );
+    var childProc = spawn('bower', 'list --map'.split(' ') );
     var sourcesSrc = '';
     childProc.stdout.setEncoding('utf8');
     childProc.stdout.on('data',  function( data ) {
@@ -21,23 +35,22 @@ module.exports = function( grunt ) {
 
     childProc.on('close', function() {
       var bowerSources = JSON.parse( sourcesSrc );
-      // set bowerMap
+      var paths = {};
 
-      // remove jquery, qunit, & EventEmitter.min.js
-      var bowerJsSources = bowerSources['.js'].filter( function( src ) {
-        var isMin = src.indexOf('.min.js') !== -1;
-        var isJquery = src.indexOf('jquery.js') !== -1;
-        var isQunit = src.indexOf('qunit.js') !== -1;
-        return !isMin && !isJquery && !isQunit;
+      // Build the paths dict from the bower config.
+      _.each(bowerSources, function(value, key) {
+        var path = extractPath(value.source.main || value.source.scripts);
+        if (path) {
+          paths[key] = path;
+        }
       });
-      // add bower JS to JS collection
-      var jsSrcs = grunt.config.get('concat.pkgd.src');
-      jsSrcs = bowerJsSources.concat( jsSrcs );
 
-      // set config so it gets concat and uglified
-      grunt.config.set( 'concat.pkgd.src', jsSrcs );
+      // Set config so requirejs can find the bower dependencies
+      grunt.config.set( 'requirejs.pkgd.options.paths', paths );
+
+      // Tell the uglify command what file to uglify.
       grunt.config.set( 'uglify.pkgd.files', {
-        'imagesloaded.pkgd.min.js': jsSrcs
+        'imagesloaded.pkgd.min.js': [grunt.config.get('requirejs.pkgd.options.out')]
       });
 
       done();


### PR DESCRIPTION
This ensures that the packaged file will work with AMD loaders (#68).

The output differs only in that the modules [are defined with a name](http://requirejs.org/docs/api.html#modulename). I tried to change as little as possible; for example, it's still using grunt-contrib-uglify to do the uglification even though grunt-contrib-requirejs can do that for you.

I took a look at [the plugin](https://github.com/yeoman/grunt-bower-requirejs) [you mentioned](https://github.com/desandro/imagesloaded/issues/68#issuecomment-18644161), but they're [still working out](https://github.com/yeoman/grunt-bower-requirejs/pull/21) some things that impact EventEmitter, so I decided to just adapt your already existing browser-list-sources task.
