### PR TITLE
Fix image.useCached function when width is not set in Chrome in very fas...

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -228,7 +228,15 @@ function defineImagesLoaded( EventEmitter, eventie ) {
 
   LoadingImage.prototype.useCached = function( cached ) {
     if ( cached.isConfirmed ) {
-      this.confirm( cached.isLoaded, 'cached was confirmed' );
+      var _this = this,
+        checkWidth = function() {
+          if (_this.img.naturalWidth !== 0) {
+            _this.confirm( cached.isLoaded, 'cached was confirmed' );
+          } else {
+            setTimeout(checkWidth, 2);
+          }
+        };
+      checkWidth();
     } else {
       var _this = this;
       cached.on( 'confirm', function( image ) {


### PR DESCRIPTION
I had an issue on Chrome in a very fast environment (using masonry)
The cached image was triggering confirm event before having their naturalWidth set.
In my case, this issue was causing bad visual issue.

Adding a setTimeout until the naturalWidth is here solves the problem for me.

In case the naturalWidth is already here, nothing is change as no setTimeout is used.