### PR TITLE
Use $ to work around missing querySelectorAll IE7

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -55,6 +55,15 @@ function extend( a, b ) {
   return a;
 }
 
+// querySelectorAll
+function select( element, selector ) {
+  if ( $ ) {
+    return $( element ).find( selector );
+  } else {
+    return element.querySelectorAll( selector );
+  }
+}
+
 var objToString = Object.prototype.toString;
 function isArray( obj ) {
   return objToString.call( obj ) === '[object Array]';
@@ -92,7 +101,7 @@ function makeArray( obj ) {
     }
     // use elem as selector string
     if ( typeof elem === 'string' ) {
-      elem = document.querySelectorAll( elem );
+      elem = select( document, elem );
     }
 
     this.elements = makeArray( elem );
@@ -137,7 +146,7 @@ function makeArray( obj ) {
         this.addImage( elem );
       }
       // find children
-      var childElems = elem.querySelectorAll('img');
+      var childElems = select( elem, 'img' );
       // concat childElems to filterFound array
       for ( var j=0, jLen = childElems.length; j < jLen; j++ ) {
         var img = childElems[j];


### PR DESCRIPTION
ref #131
