### PR TITLE
additionally test document fragment nodes

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -138,7 +138,7 @@ function makeArray( obj ) {
       }
       // find children
       // no non-element nodes, #143
-      if ( !elem.nodeType || !( elem.nodeType === 1 || elem.nodeType === 9 ) ) {
+      if ( !elem.nodeType || !( elem.nodeType === 1 || elem.nodeType === 9 || elem.nodeType === 11 ) ) {
         continue;
       }
       var childElems = elem.querySelectorAll('img');


### PR DESCRIPTION
3.1.5 breaks, at least for me, as I'm populating a document fragment before attaching the node which doesn't pass the non-element check.
