### PR TITLE
Restoring component support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,0 +1,16 @@
+{
+  "name": "imagesloaded",
+  "repo": "desandro/imagesloaded",
+  "description": "JavaScript is all like _You images done yet or what?_",
+  "version": "3.1.8",
+  "scripts": [
+    "imagesloaded.js"
+  ],
+  "main": "imagesloaded.js",
+  "dependencies": {
+    "desandro/eventie": "*",
+    "Wolfy87/EventEmitter": "*",
+    "CamShaft/require-component": "*"
+  },
+  "license": "MIT"
+}

--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -19,9 +19,12 @@
     });
   } else if ( typeof exports === 'object' ) {
     // CommonJS
+    // hacky :( ... but the line below helps address naming
+    // conflicts between browserify and component
+    require = require('require-component')(require);
     module.exports = factory(
       window,
-      require('wolfy87-eventemitter'),
+      require('eventEmitter', 'wolfy87-eventemitter'),
       require('eventie')
     );
   } else {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
     "grunt-requirejs": "~0.4.0"
   },
   "dependencies": {
-    "wolfy87-eventemitter": "4.x",
-    "eventie": ">=1.0.4 <2"
+    "eventie": ">=1.0.4 <2",
+    "require-component": "^0.1.1",
+    "wolfy87-eventemitter": "4.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves #154

It turns out that browserify and component have conflicts over the naming of [Wolfy87/EventEmitter](http://github.com/Wolfy87/EventEmitter), since they were published to npm/github with differing names.

Anyways, the best approach I found was using [require-component](https://github.com/CamShaft/require-component) to handle the resolution differences between npm/browserify and component. It's a little hacky, but I would really really like to continue using this w/ Component while still supporting the Browserify users out there. :)