### PR TITLE
Add clearCache function to ImagesLoaded

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -216,6 +216,11 @@ function makeArray( obj ) {
       }
     });
   };
+  
+  
+  ImagesLoaded.prototype.clearCache = function() {
+    cache = {};
+  };
 
   // -------------------------- jquery -------------------------- //
 


### PR DESCRIPTION
This is related to issues I experiences that affect #103 and #92.

When using JavaScript to add images to the DOM later on with the same src attribute, simply calling `imagesLoaded` again will trigger immediately for these images, even if the image has not actually loaded yet.

By hooking into the event of my (or your) app that causes the addition and calling `clearCache()` on your `ImagesLoaded` instance, you can ensure that it will trigger at the appropriate time. For example, in an Ember View:

```javascript
Ember.View.extend({
  imagesLoaded: null,

  addMasonry: function() {
    Ember.run.scheduleOnce('afterRender', this, function() {
      var $collection = this.$('.collection');

      $collection.masonry({ itemSelector: '.item' });

      this.set('imagesLoaded',
        new imagesLoaded($collection, function() {
          $collection.masonry();
        })
      );
    });
  }.on('didInsertElement'),

  removeMasonry: function() {
    this.$('.collection').masonry('destroy');
    // Calling clearCache here makes sure that imagesLoaded doesn't trigger too quickly when the
    // Ember View is reinserted into the DOM later on.
    this.get('imagesLoaded').clearCache();
  }.on('willDestroyElement')
});
```