### PR TITLE
jquery Deferred fix for jquery versions < 1.5

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -110,7 +110,7 @@ function makeArray( obj ) {
 
     this.getImages();
 
-    if ( $ ) {
+    if ( $ && $.Deferred instanceof Function) {
       // add jQuery Deferred object
       this.jqDeferred = new $.Deferred();
     }


### PR DESCRIPTION
Well, it's not a big fix/issue but when jquery < 1.5 is used (it happens sometimes in legacy code), the Deferred object/function is not available and the exception is thrown