### PR TITLE
[edit] Prefer CommonJS over AMD when loading module

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -9,7 +9,14 @@
 
   /*global define: false, module: false, require: false */
 
-  if ( typeof define === 'function' && define.amd ) {
+  if ( typeof exports === 'object' ) {
+    // CommonJS
+    module.exports = factory(
+      window,
+      require('wolfy87-eventemitter'),
+      require('eventie')
+    );
+  } else if ( typeof define === 'function' && define.amd ) {
     // AMD
     define( [
       'eventEmitter/EventEmitter',
@@ -17,13 +24,6 @@
     ], function( EventEmitter, eventie ) {
       return factory( window, EventEmitter, eventie );
     });
-  } else if ( typeof exports === 'object' ) {
-    // CommonJS
-    module.exports = factory(
-      window,
-      require('wolfy87-eventemitter'),
-      require('eventie')
-    );
   } else {
     // browser global
     window.imagesLoaded = factory(

--- a/package.json
+++ b/package.json
@@ -13,12 +13,8 @@
     "grunt-requirejs": "~0.4.0"
   },
   "dependencies": {
-    "bower": "1.3.x",
     "wolfy87-eventemitter": "4.x",
     "eventie": ">=1.0.4 <2"
-  },
-  "scripts": {
-    "postinstall": "./node_modules/bower/bin/bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[edited]
The AMD/define option is used by default when using webpack, and it fails it can't find the other dependencies (eventEmitter and eventie).

The proposed fix is to prefer CommonJS over AMD when loading the module.
It's not really a solution to the underlying problem with the AMD loading, but now it loads fine on all webpack builds, without breaking anything for anyone else.
