### PR TITLE
www: Allow `window` to default to `this`

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -33,7 +33,7 @@
     );
   }
 
-})( window,
+})( typeof window !== 'undefined' ? window : this,
 
 // --------------------------  factory -------------------------- //
 


### PR DESCRIPTION
Hi @desandro – Thanks for your work on **imagesloaded**. We are making heavy use of it over at mix.fiftythree.com and really find it useful.

We are using React to render our pages on the server-side. We use browserify to package up our modules for local and production deployment. Because our build process follows the `require` dependency tree, using the npm version of **imagesloaded** fails on the server. This is because `window` is not defined.

I made a small change here to allow `window` to fallback to `this` when it is not defined. (I also had to make a few changes in **eventie** to resolve variables there, hence the forked **eventie** dependency). Would you consider incorporating this code into an official release?

Suggestions for changes are welcome. I can remove my **eventie** fork reference when that gets updated on npm. (I will be opening a separate PR for that.)

Thanks for your time, consideration and contributions to the open source community.
