### PR TITLE
jquery path is wrong in "test/index.html"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "eventie": ">=1.0.4 <2"
   },
   "devDependencies": {
-    "jquery": ">=1.9 <2.0",
+    "jquery": ">=1.9 <1.11",
     "qunit": ">=1.10"
   },
   "ignore": [


### PR DESCRIPTION
test/index.html was broken!
![error](https://cloud.githubusercontent.com/assets/1383952/10509180/5a1c2396-7366-11e5-9b16-59825111ba43.png)


‘index’ file include jquery.
jquery changes directory from “bower_components/jquery/jquery.js" to “bower_components/jquery/dist/jquery.js" in 1.11.x over.

I fixed bower.json