### PR TITLE
Allow use of filenames which contain quotes

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -180,10 +180,10 @@ function makeArray( obj ) {
   ImagesLoaded.prototype.addElementBackgroundImages = function( elem ) {
     var style = getStyle( elem );
     // get url inside url("...")
-    var reURL = /url\(['"]*([^'"\)]+)['"]*\)/gi;
+    var reURL = /url\((['"])?(.*?)\1\)/gi;
     var matches = reURL.exec( style.backgroundImage );
     while ( matches !== null ) {
-      var url = matches && matches[1];
+      var url = matches && matches[2];
       if ( url ) {
         this.addBackground( url, elem );
       }


### PR DESCRIPTION
If a background image would have been defined as `url("where's this image.png")`, it wouldn't work with the previous regex.
And by using a backreference the quotes will always match.

Also, excluding `'` and `"` from the value between parentheses (`[^'"\)]+`) could lead to unexpected results when filenames do include them, so I replaced that with a non-greedy match-all (`.*?`).