### PR TITLE
Before creating $.Deferred object, check if jQuery supports it.

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -101,7 +101,7 @@ function ImagesLoaded( elem, options, onAlways ) {
 
   this.getImages();
 
-  if ( $ ) {
+  if ( $ && $.Deferred ) {
     // add jQuery Deferred object
     this.jqDeferred = new $.Deferred();
   }


### PR DESCRIPTION
jQuery, prior to v1.5, didn’t support deferred objects but some very old
CMS templates (although a minority) still rely on that version.

We recently ran into such a case where one of the Shopify’s templates used jQuery 1.4.2. When we added our custom gallery script which uses imagesloaded library and doesn’t depend on jQuery at all (vanilla JS), it resulted in an error when imagesloaded tried to create a Deferred object.

This pull request fixes this issue.