### PR TITLE
Check if "fn" exists in jQuery before setting plugin

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -349,7 +349,7 @@ Background.prototype.confirm = function( isLoaded, message ) {
 
 ImagesLoaded.makeJQueryPlugin = function( jQuery ) {
   jQuery = jQuery || window.jQuery;
-  if ( !jQuery ) {
+  if ( !jQuery || !jQuery.fn ) {
     return;
   }
   // set local variable


### PR DESCRIPTION
jQuery, could be wrongly initialized by other plugins and components.

We recently ran into such a case with elasticsearch library. When we added our custom gallery script which uses imagesloaded library and doesn’t depend on jQuery at all (vanilla JS), it resulted in an error when imagesloaded tried to set itself in the jQuery variable.

This pull request fixes this issue, although it will fix only specific scenarios, there should not be a reason to check this before continuing.