### PR TITLE
Safeguard to check if jQuery.fn and jQuery.Deferred exists before using...

### DIFF
--- a/imagesloaded.js
+++ b/imagesloaded.js
@@ -101,7 +101,7 @@ function ImagesLoaded( elem, options, onAlways ) {
 
   this.getImages();
 
-  if ( $ ) {
+  if ( $ && $.Deferred ) {
     // add jQuery Deferred object
     this.jqDeferred = new $.Deferred();
   }
@@ -349,7 +349,7 @@ Background.prototype.confirm = function( isLoaded, message ) {
 
 ImagesLoaded.makeJQueryPlugin = function( jQuery ) {
   jQuery = jQuery || window.jQuery;
-  if ( !jQuery ) {
+  if ( !jQuery || !jQuery.fn ) {
     return;
   }
   // set local variable

--- a/imagesloaded.pkgd.js
+++ b/imagesloaded.pkgd.js
@@ -223,7 +223,7 @@ function ImagesLoaded( elem, options, onAlways ) {
 
   this.getImages();
 
-  if ( $ ) {
+  if ( $ && $.Deferred ) {
     // add jQuery Deferred object
     this.jqDeferred = new $.Deferred();
   }
@@ -471,7 +471,7 @@ Background.prototype.confirm = function( isLoaded, message ) {
 
 ImagesLoaded.makeJQueryPlugin = function( jQuery ) {
   jQuery = jQuery || window.jQuery;
-  if ( !jQuery ) {
+  if ( !jQuery || !jQuery.fn ) {
     return;
   }
   // set local variable


### PR DESCRIPTION
Error from 3rd Party script using imagesLoaded:
```
imagesloaded.pkgd.js:480 Uncaught TypeError: Cannot set property 'imagesLoaded' of undefined
    at Function.ImagesLoaded.makeJQueryPlugin (imagesloaded.pkgd.js:480)
    at factory (imagesloaded.pkgd.js:486)
    at imagesloaded.pkgd.js:149
    at imagesloaded.pkgd.js:155
```

We are trying to improve our pageload times due to render-blocking jQuery, and this error just came up for us from an external script that is using imagesLoaded.

In our implementation we are defining our own jQuery global in the header of our document to catch all inline jQuery commands in the body, and then towards the footer, after the actual jQuery library is loaded (which is async/deferred too) we are processing those catches. Since we're only catching a few common jQuery objects used on our platform (ready, on, bind, click), we are not including `$.fn` or `$.Deferred` so imagesLoaded is actually looking at our jQuery global and errors out because it cannot find those functions.

I know this is a rare case of using jQuery, but our platform is full of clients with some inline javascript in areas we just cannot bulk update and change in a snap. I believe there should be a check if `$.fn` and `$.Deferred` exists before using them. If, in a different world, jQuery removes these functions, imagesLoaded would break, so I think checking before using would be ideal.