### PR TITLE
Loading image from object tag

### DIFF
--- a/imagesloaded.pkgd.js
+++ b/imagesloaded.pkgd.js
@@ -260,8 +260,7 @@ ImagesLoaded.prototype.addElementImages = function( elem ) {
     this.addElementBackgroundImages( elem );
   }
   
-  if ( elem.nodeName == 'OBJECT' ) {
-    console.log("element is OBJECT");
+  if ( elem.nodeName == 'OBJECT' && elem.hasAttribute("type") && elem.getAttribute("type").startsWith("image") ) {
     this.addObjectImage( elem );
   }
 

--- a/imagesloaded.pkgd.js
+++ b/imagesloaded.pkgd.js
@@ -259,6 +259,11 @@ ImagesLoaded.prototype.addElementImages = function( elem ) {
   if ( this.options.background === true ) {
     this.addElementBackgroundImages( elem );
   }
+  
+  if ( elem.nodeName == 'OBJECT' ) {
+    console.log("element is OBJECT");
+    this.addObjectImage( elem );
+  }
 
   // find children
   // no non-element nodes, #143
@@ -279,6 +284,15 @@ ImagesLoaded.prototype.addElementImages = function( elem ) {
     for ( i=0; i < children.length; i++ ) {
       var child = children[i];
       this.addElementBackgroundImages( child );
+    }
+  }
+  
+  // get child object images
+  if ( this.options.objects === true ) {
+    var children_objects = elem.querySelectorAll('object[type^="image"]');
+    for ( i=0; i < children_objects.length; i++ ) {
+      var child_object = children_objects[i];
+      this.addObjectImage( child_object );
     }
   }
 };
@@ -318,6 +332,11 @@ ImagesLoaded.prototype.addImage = function( img ) {
 ImagesLoaded.prototype.addBackground = function( url, elem ) {
   var background = new Background( url, elem );
   this.images.push( background );
+};
+  
+ImagesLoaded.prototype.addObjectImage = function( elem ) {
+  var objectImage = new ObjectImage( elem );
+  this.images.push( objectImage );
 };
 
 ImagesLoaded.prototype.check = function() {
@@ -467,6 +486,39 @@ Background.prototype.unbindEvents = function() {
 };
 
 Background.prototype.confirm = function( isLoaded, message ) {
+  this.isLoaded = isLoaded;
+  this.emitEvent( 'progress', [ this, this.element, message ] );
+};
+  
+// -------------------------- OjectImage -------------------------- //
+
+function ObjectImage( object_element ) {
+  this.url = object_element.data;
+  this.element = object_element;
+  this.img = new Image();
+}
+
+// inherit LoadingImage prototype
+ObjectImage.prototype = Object.create( LoadingImage.prototype );
+
+ObjectImage.prototype.check = function() {
+  this.img.addEventListener( 'load', this );
+  this.img.addEventListener( 'error', this );
+  this.img.src = this.url;
+  // check if image is already complete
+  var isComplete = this.getIsImageComplete();
+  if ( isComplete ) {
+    this.confirm( this.img.naturalWidth !== 0, 'naturalWidth' );
+    this.unbindEvents();
+  }
+};
+
+ObjectImage.prototype.unbindEvents = function() {
+  this.img.removeEventListener( 'load', this );
+  this.img.removeEventListener( 'error', this );
+};
+
+ObjectImage.prototype.confirm = function( isLoaded, message ) {
   this.isLoaded = isLoaded;
   this.emitEvent( 'progress', [ this, this.element, message ] );
 };


### PR DESCRIPTION
I came across the need to load images from an object tag. After not finding a good enough solution elsewhere, I thought it would be a nice addition to the plugin. For this to work there are two requirements:
1) There has to be an option `objects: true` set in the imagesLoaded call,
2) The object tags need to have `type="image/***"` attribute specified (to avoid unnecessary loading of objects).

There might be more issues that need to be covered if this is to be merged, however I thought I'd share in case anyone else needs that functionality. Any thoughts welcome.